### PR TITLE
feat: improve codeblock styling and warning boxe style

### DIFF
--- a/src/components/StartBuilding.css
+++ b/src/components/StartBuilding.css
@@ -326,6 +326,29 @@ code {
   color: var(--text-primary);
 }
 
+.warning-box strong {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.warning-box ul {
+  margin: 0;
+  padding-left: 1.5rem;
+  list-style-type: disc;
+}
+
+.warning-box li {
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.warning-box li:last-child {
+  margin-bottom: 0;
+}
+
 .success-box {
   background: rgba(40, 167, 69, 0.1);
   border: 1px solid rgba(40, 167, 69, 0.3);
@@ -359,10 +382,8 @@ code {
 }
 
 .clone-method {
-  background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 1rem;
   transition: all 0.2s ease;
 }
 
@@ -391,14 +412,17 @@ code {
 
 /* Links */
 .step-card a {
-  color: var(--primary);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color 0.2s;
+  color: #00d4ff;
+  transition: all 0.2s;
+  font-weight: 500;
+  padding: 0.125rem 0.25rem;
+  border-radius: 4px;
 }
 
 .step-card a:hover {
-  border-bottom-color: var(--primary);
+  border-bottom-color: transparent;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 212, 255, 0.3);
 }
 
 /* Project Structure */
@@ -998,6 +1022,7 @@ code {
   .info-box ul,
   .warning-box ul {
     margin-left: 1rem;
+    padding-left: 1.25rem;
   }
 
   /* Git install tabs - mobile */

--- a/src/components/steps/CodeBlock.css
+++ b/src/components/steps/CodeBlock.css
@@ -4,10 +4,6 @@
   margin: 1.5rem 0;
   border-radius: 12px;
   overflow: hidden;
-  background: var(--code-bg, #1e1e1e);
-  border: 1px solid var(--code-border, #333);
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  transition: all 0.2s ease;
 }
 
 .code-block-wrapper:hover {
@@ -20,20 +16,20 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 1rem;
-  background: var(--code-header-bg, #2d2d2d);
-  border-bottom: 1px solid var(--code-border, #333);
+  background: var(--code-header-bg);
+  border-bottom: 1px solid var(--code-border);
   font-size: 0.875rem;
 }
 
 .file-name {
-  color: var(--code-filename, #9ca3af);
+  color: var(--code-filename);
   font-weight: 500;
 }
 
 .language-badge {
   padding: 0.25rem 0.5rem;
-  background: var(--code-badge-bg, #374151);
-  color: var(--code-badge-color, #9ca3af);
+  background: var(--code-badge-bg);
+  color: var(--code-badge-color);
   border-radius: 4px;
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -49,13 +45,6 @@
   border-radius: 12px;
 }
 
-/* Line numbers are now handled by react-syntax-highlighter */
-
-/* SyntaxHighlighter container */
-.code-block-container {
-  overflow: hidden;
-}
-
 /* Wrapper to isolate syntax highlighter styles */
 .syntax-highlighter-wrapper {
   width: 100%;
@@ -65,28 +54,10 @@
 .syntax-highlighter-wrapper > pre {
   flex: 1;
   margin: 0 !important;
-  background-color: transparent !important;
-  background-image: none !important;
   overflow-x: auto !important;
   overflow-y: hidden !important;
   -webkit-overflow-scrolling: touch;
   max-width: 100%;
-}
-
-/* Override any background shorthand from syntax highlighter */
-.syntax-highlighter-wrapper pre[style] {
-  background: transparent !important;
-  background-color: transparent !important;
-}
-
-/* Light theme specific overrides */
-.light .syntax-highlighter-wrapper pre[style] {
-  background: var(--code-bg) !important;
-  background-color: var(--code-bg) !important;
-}
-
-.light .code-block-container {
-  background: var(--code-bg);
 }
 
 /* Ensure code doesn't overflow */
@@ -103,15 +74,15 @@
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  background: var(--code-copy-bg, #374151);
-  border: 1px solid var(--code-copy-border, #4b5563);
+  background: var(--code-copy-bg);
+  border: 1px solid var(--code-copy-border);
   border-radius: 6px;
   padding: 0.5rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--code-copy-color, #9ca3af);
+  color: var(--code-copy-color);
   z-index: 2;
   opacity: 0;
   transition: all 0.2s ease;
@@ -129,8 +100,8 @@
 }
 
 .copy-button:hover {
-  background: var(--code-copy-hover-bg, #4b5563);
-  color: var(--code-copy-hover-color, #e5e7eb);
+  background: var(--code-copy-hover-bg);
+  color: var(--code-copy-hover-color);
   transform: translateY(-1px);
 }
 
@@ -143,43 +114,13 @@
   height: 16px;
 }
 
-/* Remove custom syntax highlighting - now handled by react-syntax-highlighter */
-
-/* Light Theme */
-.light .code-block-wrapper {
-  background: var(--code-bg, #f9fafb);
-  border-color: var(--code-border, #e5e7eb);
-}
-
-.light .code-block-header {
-  background: var(--code-header-bg, #f3f4f6);
-  border-bottom-color: var(--code-border, #e5e7eb);
-}
-
-.light .language-badge {
-  background: var(--code-badge-bg, #e5e7eb);
-  color: var(--code-badge-color, #6b7280);
-}
-
-.light .copy-button {
-  background: var(--code-copy-bg, #ffffff);
-  border-color: var(--code-copy-border, #e5e7eb);
-  color: var(--code-copy-color, #6b7280);
-}
-
-.light .copy-button:hover {
-  background: var(--code-copy-hover-bg, #f3f4f6);
-  color: var(--code-copy-hover-color, #111827);
-}
-
 /* CSS Variables for customization */
 :root {
   /* Dark theme defaults */
-  --code-bg: #1e1e1e;
-  --code-header-bg: #2d2d2d;
-  --code-border: #333;
+  --code-bg: #0d1117;
+  --code-header-bg: #161b22;
+  --code-border: #30363d;
   --code-text: #e5e7eb;
-  --code-line-number: #4a5568;
   --code-filename: #9ca3af;
   --code-badge-bg: #374151;
   --code-badge-color: #9ca3af;
@@ -191,11 +132,10 @@
 }
 
 .light {
-  --code-bg: #f9fafb;
-  --code-header-bg: #f3f4f6;
-  --code-border: #e5e7eb;
+  --code-bg: #f6f8fa;
+  --code-header-bg: #f1f3f4;
+  --code-border: #d1d9e0;
   --code-text: #111827;
-  --code-line-number: #9ca3af;
   --code-filename: #6b7280;
   --code-badge-bg: #e5e7eb;
   --code-badge-color: #6b7280;
@@ -204,6 +144,27 @@
   --code-copy-color: #6b7280;
   --code-copy-hover-bg: #f3f4f6;
   --code-copy-hover-color: #111827;
+}
+
+:root .code-block-wrapper *,
+.dark .code-block-wrapper * {
+  background: #0D1117 !important;
+  background-color: #0D1117 !important;
+}
+
+.light .code-block-wrapper * {
+  background: #f6f8fa !important;
+  background-color: #f6f8fa !important;
+}
+
+.light .code-block-wrapper {
+  background: var(--code-bg);
+  border-color: var(--code-border);
+}
+
+.light .code-block-header {
+  background: var(--code-header-bg);
+  border-bottom-color: var(--code-border);
 }
 
 /* Responsive adjustments */
@@ -241,5 +202,5 @@
 }
 
 .code-block-container::-webkit-scrollbar-thumb:hover {
-  background: var(--code-line-number);
+  background: #6b7280;
 }

--- a/src/components/steps/CodeBlock.css
+++ b/src/components/steps/CodeBlock.css
@@ -148,8 +148,8 @@
 
 :root .code-block-wrapper *,
 .dark .code-block-wrapper * {
-  background: #0D1117 !important;
-  background-color: #0D1117 !important;
+  background: #0d1117 !important;
+  background-color: #0d1117 !important;
 }
 
 .light .code-block-wrapper * {


### PR DESCRIPTION
## 📋 Description

This PR improves styling across multiple UI components to enhance visual consistency and user experience:

### 🎨 **Code Blocks:**
- Implemented GitHub-style background (#0D1117) for dark theme

### ⚠️ **Warning Box:**
- Improved content indentation and spacing for better readability
- Adjusted padding and margins for consistent alignment

### 🔗 **Link Highlighting:**
- Enhanced link color visibility and contrast
- Improved hover states and focus indicators
- Added better visual distinction for external links

## 🔄 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Tested across different themes (dark/light)
- [x] Verified responsive behavior on different screen sizes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works *(Not applicable for styling changes)*
- [ ] New and existing unit tests pass locally with my changes *(Not applicable)*
- [ ] Any dependent changes have been merged and published *(Not applicable)*

## 📸 Screenshots
### WARNING BOX:
Before:
![Screenshot 2025-06-06 at 19 21 52](https://github.com/user-attachments/assets/0ff9568d-11c1-4772-8ef0-2bd36a769c3d)
After:
![Screenshot 2025-06-06 at 19 21 26](https://github.com/user-attachments/assets/4925e08f-799a-4926-a49b-a3f9797215f1)

### CODE BLOCK:
Before:
![Screenshot 2025-06-06 at 19 23 02](https://github.com/user-attachments/assets/b9437dcd-3155-421e-84b9-b9639a903b4f)

After:
![Screenshot 2025-06-06 at 19 22 27](https://github.com/user-attachments/assets/37f523be-345c-41a9-8458-7f06f69dc410)


### LINK HIGHLIGHTING

Before (Changes in the [git-scm.com](https://git-scm.com/)):
![Screenshot 2025-06-06 at 19 25 40](https://github.com/user-attachments/assets/b628ed56-5eac-4544-b313-f4aa0455036b)

After:
![Screenshot 2025-06-06 at 19 25 19](https://github.com/user-attachments/assets/fcd25761-7665-4c4a-b7ae-0b04833ec31b)

### Background color change

Before:
![Screenshot 2025-06-06 at 19 27 07](https://github.com/user-attachments/assets/7cefcb2b-b143-4756-a4f9-eaad8f590d3e)

After:
![Screenshot 2025-06-06 at 19 27 56](https://github.com/user-attachments/assets/ccab1aa0-90a2-4e39-b41d-444d08863d21)
